### PR TITLE
Fix development env (VSCode and nix develop)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,9 +89,10 @@
           };
           # Used by `nix develop ...`
           devShells = {
-            default = project false;
+            default = project true;
           };
           # For compatability with older Nix (eg in CI)
+          devShell = inputs.self.devShells.${system}.default;
           defaultPackage = inputs.self.packages.${system}.default;
           defaultApp = inputs.self.apps.${system}.default;
         };


### PR DESCRIPTION
On my machine, the latest refactoring seems to have broken the development environment and I could not access any of the dependencies specified in `shellDeps` or use any of the tools required by VSCode without this fix