### PR TITLE
Remove redundant dependencies

### DIFF
--- a/haskell-template.cabal
+++ b/haskell-template.cabal
@@ -77,17 +77,14 @@ common shared
     , aeson
     , async
     , base          >=4.13.0.0 && <=4.18.0.0
-    , bytestring
-    , containers
     , data-default
     , directory
     , filepath
     , mtl
     , optics-core
     , profunctors
-    , relude
+    , relude        >=1.0
     , shower
-    , text
     , time
     , with-utf8
 


### PR DESCRIPTION
Relude reexports most common modules from the following libraries:
  - containers
  - unordered-containers
  - text
  - bytestring
So we can remove these from our build-depends list.
More information: https://github.com/kowainik/relude/issues/353