### PR TITLE
Add Nix template

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,21 @@
         # Default shell.
         devShells.default =
           config.mission-control.installToDevShell self'.devShells.main;
+        
+        # Default template
+        templates.default = {
+          path = ./.;
+          description = ''
+            Create a Haskell template with the Nix CLI instead of through Github    
+          '';
+          welcomeText = ''
+            You just created an instance of Sridhar Ratnakumar's Haskell template!
+            The core maintainer, who goes by Srid, is an afficionado of Haskell, Nix,
+            and all things functional programming!
+            
+            Read more about Srid on his publicly-available personal website: https://srid.ca
+          '';
+        };
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -92,9 +92,11 @@
         # Default shell.
         devShells.default =
           config.mission-control.installToDevShell self'.devShells.main;
-        
+      };
+
+      flake = {
         # Default template
-        templates.default = {
+        defaultTemplate = {
           path = ./.;
           description = ''
             Create a Haskell template with the Nix CLI instead of through Github    
@@ -103,7 +105,7 @@
             You just created an instance of Sridhar Ratnakumar's Haskell template!
             The core maintainer, who goes by Srid, is an afficionado of Haskell, Nix,
             and all things functional programming!
-            
+              
             Read more about Srid on his publicly-available personal website: https://srid.ca
           '';
         };


### PR DESCRIPTION
Low-hanging fruit for ease of use

We can now `nix flake init -t github:srid/haskell-template` in the shell and get this template without having to do anything in the browser