### PR TITLE
Switch from `treefmt` -> `pre-commit`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ result-*
 
 # direnv
 .direnv
+
+/.pre-commit-config.yaml

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Get a Haskell development environment up and running quickly. Thanks to Nix, thi
 
 - [Nix](https://srid.ca/haskell-nix) + [Flakes](https://serokell.io/blog/practical-nix-flakes) (via [`github:srid/haskell-flake`](https://github.com/srid/haskell-flake)) + GHC 9.6
 - VSCode + [HLS](https://github.com/haskell/haskell-language-server)
-- [fourmolu](https://github.com/fourmolu/fourmolu) autoformatting 
+- [fourmolu](https://github.com/fourmolu/fourmolu) autoformatting
 - [Relude](https://github.com/kowainik/relude) as Prelude.
   - `.hlint.yaml` is [from relude](https://github.com/kowainik/relude/blob/main/.hlint.yaml)
 - Devshell commands are provided via [just](https://just.systems/); run `just` in devshell.
@@ -30,7 +30,7 @@ Recommended dev environment setup: https://nixos.asia/en/direnv
 
 - Run `nix flake update` to update all flake inputs.
 - Run `nix --accept-flake-config run github:juspay/omnix ci` to build _all_ outputs.
-- Run `just fmt` in nix shell to autoformat the project. This uses [treefmt](https://github.com/numtide/treefmt).
+- Run `just fmt` in nix shell to autoformat the project. This uses [pre-commit].
 - Run `just docs` to start Hoogle with packages in your cabal file.
 - Run the application without installing: `nix run github:srid/haskell-template` (or `nix run .` from checkout)
 - Common workflows
@@ -40,3 +40,5 @@ Recommended dev environment setup: https://nixos.asia/en/direnv
 ## Discussions
 
 Questions? Ideas? Suggestions? Join our [NixOS Zulip](https://nixos.zulipchat.com/#narrow/stream/413949-haskell-flake) or post in [Github Discussions](https://github.com/srid/haskell-template/discussions).
+
+[pre-commit]: https://github.com/cachix/git-hooks.nix

--- a/flake.lock
+++ b/flake.lock
@@ -35,6 +35,22 @@
         "type": "github"
       }
     },
+    "git-hooks": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "haskell-flake": {
       "locked": {
         "lastModified": 1731272671,
@@ -85,30 +101,10 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "fourmolu-nix": "fourmolu-nix",
+        "git-hooks": "git-hooks",
         "haskell-flake": "haskell-flake",
         "nixos-unified": "nixos-unified",
-        "nixpkgs": "nixpkgs",
-        "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1731959974,
-        "narHash": "sha256-AsuUJfILHGteNuQgCuiWPzWOVgzBsbetUHRAVwW7FCw=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "675d4a7fc531799ae8dfca1986b79be7660559e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -6,9 +6,10 @@
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
     nixos-unified.url = "github:srid/nixos-unified";
     haskell-flake.url = "github:srid/haskell-flake";
-    treefmt-nix.url = "github:numtide/treefmt-nix";
-    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
     fourmolu-nix.url = "github:jedimahdi/fourmolu-nix";
+
+    git-hooks.url = "github:cachix/git-hooks.nix";
+    git-hooks.flake = false;
   };
 
   outputs = inputs:

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ repl *ARGS:
 
 # Autoformat the project tree
 fmt:
-    treefmt
+    pre-commit run --all-files
 
 # Run ghcid -- auto-recompile and run `main` function
 run:

--- a/nix/modules/flake-parts/devshell.nix
+++ b/nix/modules/flake-parts/devshell.nix
@@ -7,7 +7,7 @@
       # See https://community.flake.parts/haskell-flake/devshell#composing-devshells
       inputsFrom = [
         config.haskellProjects.default.outputs.devShell # See ./nix/modules/haskell.nix
-        config.treefmt.build.devShell # See ./nix/modules/formatter.nix
+        config.pre-commit.devShell # See ./nix/modules/formatter.nix
       ];
       packages = with pkgs; [
         just

--- a/nix/modules/flake-parts/formatter.nix
+++ b/nix/modules/flake-parts/formatter.nix
@@ -1,32 +1,20 @@
 { inputs, ... }:
 {
   imports = [
-    inputs.treefmt-nix.flakeModule
+    (inputs.git-hooks + /flake-module.nix)
     inputs.fourmolu-nix.flakeModule
   ];
-  perSystem = { config, pkgs, ... }: {
-    # Auto formatters. This also adds a flake check to ensure that the
-    # source tree was auto formatted.
-    treefmt.config = {
-      projectRootFile = "flake.nix";
-
-      settings.global.excludes = [
-        ".*"
-        "*.sql" # https://github.com/numtide/treefmt-nix/issues/257
-        "*.md"
-        "hie.yaml"
-        "LICENSE"
-      ];
-
-      programs.just.enable = true;
-      settings.formatter.just.includes = [ "justfile" ];
-      programs.fourmolu = {
-        enable = true;
-        package = config.fourmolu.wrapper;
+  perSystem = { config, ... }: {
+    pre-commit.settings = {
+      hooks = {
+        nixpkgs-fmt.enable = true;
+        cabal-fmt.enable = true;
+        fourmolu = {
+          enable = true;
+          package = config.fourmolu.wrapper;
+        };
+        hlint.enable = true;
       };
-      programs.nixpkgs-fmt.enable = true;
-      programs.cabal-fmt.enable = true;
-      programs.hlint.enable = true;
     };
 
     fourmolu.settings = {


### PR DESCRIPTION
I feel that the quality of `treemt` has lately declined. For eg., recent versions started dumping a bunch of needless noise (why is it now trying to format all files in repo?):

![image](https://github.com/user-attachments/assets/9aa15526-1081-41f1-85f4-7dc2034b24d2)

which then required more configuration in Nix to fix:

https://github.com/srid/haskell-template/commit/d8c7e63731d9b63ef5937cb3fdc8694046ea6c39

And this unnecessarily extra config will vary across projects, depending on the files they have.

---

We strictly don't need treefmt though (besides, [not everyone](https://x.com/sridca/status/1808605343674450157) is allowed to contribute) because that's what `pre-commit run -a` is for. 

To that end, this PR gets rid of `treefmt` and switches to https://github.com/cachix/git-hooks.nix (the Nix module for https://pre-commit.com/).

Functionality more or less remains the same - except for losing `just` formatter (which can be added to git-hooks.nix) and of course gaining git pre-commit hooks setup in devShell.