### PR TITLE
Use `StrictData`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1734464164,
-        "narHash": "sha256-5JCCyrgy7IMnipyYMQzIAXncGt2XVlW1aK71A+FTXDs=",
+        "lastModified": 1734703440,
+        "narHash": "sha256-QQbB7e9DQwKCjuLIMQjd9KTpeyvssK9muNAS7hR98y0=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "e280b39efdd72b6a5bdaa982b67f150c819be642",
+        "rev": "72a4c403230c4b8bcfa5571c3b7e76253fc8d966",
         "type": "github"
       },
       "original": {

--- a/haskell-template.cabal
+++ b/haskell-template.cabal
@@ -41,6 +41,7 @@ common shared
     MultiWayIf
     NoStarIsType
     OverloadedStrings
+    StrictData
     TypeFamilies
     ViewPatterns
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE StrictData #-}
-
 module Main where
 
 import Main.Utf8 qualified as Utf8

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,6 +1,14 @@
+{-# LANGUAGE StrictData #-}
+
 module Main where
 
 import Main.Utf8 qualified as Utf8
+
+data Example = Example
+  { name :: Text
+  , age :: Int
+  }
+  deriving stock (Show, Eq)
 
 {- |
  Main entry point.


### PR DESCRIPTION
Repro for https://github.com/kowainik/stan/issues/392

Run this command to get the path to the stan report,

```
echo $(nix build --print-out-paths)/stan.html
```

Despite using `StrictData` in both the cabal file and the module (`Main.hs`), notice that stan will fail to recoginze it:

![image](https://github.com/user-attachments/assets/8fb9cf21-1dcc-44fb-ab57-a166190a467f)
